### PR TITLE
Feature/upgrade grpc lib

### DIFF
--- a/Microservice Source Code/EmailService/pom.xml
+++ b/Microservice Source Code/EmailService/pom.xml
@@ -57,17 +57,17 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.devh</groupId>

--- a/Microservice Source Code/EmailService/pom.xml
+++ b/Microservice Source Code/EmailService/pom.xml
@@ -70,6 +70,22 @@
 			<version>1.61.1</version>
 		</dependency>
 		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-context</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-api</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-services</artifactId>
+			<version>1.61.1</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>net.devh</groupId>
 			<artifactId>grpc-server-spring-boot-starter</artifactId>
 			<version>2.14.0.RELEASE</version>

--- a/Microservice Source Code/LogsService/pom.xml
+++ b/Microservice Source Code/LogsService/pom.xml
@@ -39,17 +39,17 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.devh</groupId>

--- a/Microservice Source Code/LogsService/pom.xml
+++ b/Microservice Source Code/LogsService/pom.xml
@@ -52,6 +52,22 @@
 			<version>1.61.1</version>
 		</dependency>
 		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-context</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-api</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-services</artifactId>
+			<version>1.61.1</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>net.devh</groupId>
 			<artifactId>grpc-server-spring-boot-starter</artifactId>
 			<version>2.14.0.RELEASE</version>

--- a/Microservice Source Code/PasswordService/pom.xml
+++ b/Microservice Source Code/PasswordService/pom.xml
@@ -61,6 +61,22 @@
 			<version>1.61.1</version>
 		</dependency>
 		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-context</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-api</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-services</artifactId>
+			<version>1.61.1</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>net.devh</groupId>
 			<artifactId>grpc-server-spring-boot-starter</artifactId>
 			<version>2.14.0.RELEASE</version>

--- a/Microservice Source Code/PasswordService/pom.xml
+++ b/Microservice Source Code/PasswordService/pom.xml
@@ -48,17 +48,17 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.devh</groupId>

--- a/Microservice Source Code/UserService/pom.xml
+++ b/Microservice Source Code/UserService/pom.xml
@@ -65,6 +65,22 @@
 			<version>1.61.1</version>
 		</dependency>
 		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-context</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-api</artifactId>
+			<version>1.61.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-services</artifactId>
+			<version>1.61.1</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>net.devh</groupId>
 			<artifactId>grpc-server-spring-boot-starter</artifactId>
 			<version>2.14.0.RELEASE</version>

--- a/Microservice Source Code/UserService/pom.xml
+++ b/Microservice Source Code/UserService/pom.xml
@@ -52,17 +52,17 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
-			<version>1.51.0</version>
+			<version>1.61.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.devh</groupId>


### PR DESCRIPTION
Upgrade the GRPC Lib from 1.51.0 to 1.61.0 version. Add some additional GRPC version to run the GRPC without having any issues.